### PR TITLE
fix yellow "now" link on light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ redirect_from:
     <p>
       Welcome to my corner of the internet.
       If you aren't sure where to start, try my
-      <a class="outline-none underline hover:underline text-yellow-100 bhover:text-blue-600" href="{% link _pages/now.md %}">now</a> page.
+      <a class="outline-none underline hover:underline dark:text-yellow-100 bhover:text-blue-600" href="{% link _pages/now.md %}">now</a> page.
     </p>
   </section>
 


### PR DESCRIPTION
before 
<img width="1009" alt="Screenshot 2024-11-01 at 3 04 38 PM" src="https://github.com/user-attachments/assets/97e2b5cb-5a0f-44e5-b96a-b7af2a537575">


after
<img width="967" alt="Screenshot 2024-11-01 at 3 04 28 PM" src="https://github.com/user-attachments/assets/a045b0a3-3a30-4720-8b7b-25626b264cc9">
